### PR TITLE
renaming the Quit menu item on MacOS

### DIFF
--- a/electron/app/js/wktWindow.js
+++ b/electron/app/js/wktWindow.js
@@ -512,8 +512,8 @@ class WktAppMenu {
             type: 'separator'
           },
           {
-            id: 'quit',
-            label: `${i18n.t('menu-app-quit', { appName: this._wktApp.getApplicationName() })}`,
+            id: 'exit',
+            label: `${i18n.t('menu-app-exit', { appName: this._wktApp.getApplicationName() })}`,
             accelerator: 'Command+Q',
             async click() { await executeAppQuit(); }
           }
@@ -587,7 +587,7 @@ class WktAppMenu {
           },
           { type: 'separator' },
           {
-            id: 'quit',
+            id: 'exit',
             label: i18n.t('menu-file-exit'),
             accelerator: 'Alt+X',
             async click() { await executeAppQuit(); }          }

--- a/electron/app/locales/en/electron.json
+++ b/electron/app/locales/en/electron.json
@@ -73,7 +73,7 @@
   "menu-app-hide": "Hide {{appName}}",
   "menu-app-hideOthers": "Hide Others",
   "menu-app-showAll": "Show All",
-  "menu-app-quit": "Quit",
+  "menu-app-exit": "Exit",
 
   "dialog-chooseArchiveFile": "Select an Archive File",
   "dialog-chooseModelFile": "Select a Model File",

--- a/electron/app/main.js
+++ b/electron/app/main.js
@@ -115,6 +115,7 @@ class Main {
     });
 
     app.on('ready', () => {
+      getLogger().debug('Received ready event');
       if (!this._openFileCreateWindowAlreadyCalled) {
         let filePath;
         if (process.platform !== 'darwin') {


### PR DESCRIPTION
renaming the Quit menu item on MacOS to Exit to be consistent with Windows and Linux