### PR TITLE
Change ingress routes access point look and feel

### DIFF
--- a/electron/app/js/ipcRendererPreload.js
+++ b/electron/app/js/ipcRendererPreload.js
@@ -152,6 +152,7 @@ contextBridge.exposeInMainWorld(
           'k8s-get-service-details',
           'k8s-get-operator-version-from-dm',
           'k8s-get-k8s-config',
+          'k8s-get-k8s-cluster-info',
           'k8s-get-wko-domain-status',
           'k8s-get-operator-status',
           'k8s-get-operator-log',

--- a/electron/app/js/kubectlUtils.js
+++ b/electron/app/js/kubectlUtils.js
@@ -109,6 +109,28 @@ async function getK8sConfigView(kubectlExe, options) {
   });
 }
 
+async function getK8sClusterInfo(kubectlExe, options) {
+  const args = [ 'cluster-info'];
+  const httpsProxyUrl = await getHttpsProxyUrl();
+  const bypassProxyHosts = await getBypassProxyHosts();
+  const env = getKubectlEnvironment(options, httpsProxyUrl, bypassProxyHosts);
+  const results = {
+    isSuccess: true
+  };
+
+  return new Promise(resolve => {
+    executeFileCommand(kubectlExe, args, env).then(clusterInfo => {
+      results['clusterInfo'] = clusterInfo;
+      resolve(results);
+    }).catch(err => {
+      results.isSuccess = false;
+      results.reason =
+        i18n.t('kubectl-config-view-error-message',{ error: getErrorMessage(err) });
+      resolve(results);
+    });
+  });
+}
+
 async function getWkoDomainStatus(kubectlExe, domainUID, domainNamespace, options) {
   const args = [ 'get', 'domain', domainUID, '-n', domainNamespace, '-o', 'json'];
   const httpsProxyUrl = await getHttpsProxyUrl();
@@ -752,6 +774,7 @@ module.exports = {
   deleteObjectIfExists,
   getServiceDetails,
   getK8sConfigView,
+  getK8sClusterInfo,
   getWkoDomainStatus,
   getOperatorStatus,
   getOperatorVersionFromDomainCM,

--- a/electron/app/main.js
+++ b/electron/app/main.js
@@ -737,6 +737,10 @@ class Main {
       return kubectlUtils.getK8sConfigView(kubectlExe, options);
     });
 
+    ipcMain.handle('k8s-get-k8s-cluster-info', async (event, kubectlExe, options) => {
+      return kubectlUtils.getK8sClusterInfo(kubectlExe, options);
+    });
+
     ipcMain.handle('k8s-get-wko-domain-status', async (event, kubectlExe, domainUID, domainNamespace, options) => {
       return kubectlUtils.getWkoDomainStatus(kubectlExe, domainUID, domainNamespace, options);
     });

--- a/webui/src/js/utils/ingress-routes-helper.js
+++ b/webui/src/js/utils/ingress-routes-helper.js
@@ -455,30 +455,16 @@ function(project, wktConsole, k8sHelper, i18n, projectIo, dialogHelper, validati
     };
 
     this.getk8sClusterAddress = async (kubectlExe, currentContext, kubectlOptions) => {
-      const results = await window.api.ipc.invoke('k8s-get-k8s-config',
+      const results = await window.api.ipc.invoke('k8s-get-k8s-cluster-info',
         kubectlExe, kubectlOptions);
-      let cluster = '';
-      let server = '';
-      if (results.isSuccess) {
-        const configView = results.configView;
-        for (const item of configView.contexts) {
-          if (item.name === configView['current-context']) {
-            cluster = item.context.cluster;
-            break;
-          }
-        }
-        if (cluster !== '') {
-          for (const item of configView.clusters) {
-            if (item.name === cluster) {
-              server = item.cluster.server;
-              const address = server.split(':');
-              results['server'] = address[1];
-              break;
-            }
-          }
-        }
-        return Promise.resolve(results);
 
+      if (results.isSuccess) {
+        // Get the first line of kubectl cluster-info and parse the control pane url
+        const controlPaneLine = results.clusterInfo.split('\n',1)[0];
+        const tokens = controlPaneLine.split(' ');
+        const clusterUrl = tokens[tokens.length - 1].split(':')[1];
+        results['server'] = clusterUrl;
+        return Promise.resolve(results);
       } else {
         return Promise.resolve(results);
       }

--- a/webui/src/js/views/ingress-design-view.html
+++ b/webui/src/js/views/ingress-design-view.html
@@ -202,7 +202,9 @@
           </oj-bind-if>
           <oj-bind-if test="[[isAccessPointDefined(row.data.accessPoint)]]">
             <td class="wkt-link-container" data-bind="attr: { title: row.data.accessPoint }">
-              <a data-bind="attr: { href: row.data.accessPoint }">click</a>
+              <a data-bind="attr: { href: row.data.accessPoint }">
+                <oj-bind-text value="[[row.data.accessPoint]]"></oj-bind-text>
+              </a>
             </td>
           </oj-bind-if>
 


### PR DESCRIPTION
This PR changes to use the actual url in the anchor link of the access point in the ingress routes table and also switched to use `kubectl cluster-info` for getting k8s cluster address.   On some local k8s development environment such as docker desktop and kind, the cluster address returned by `kubectl config view` is confusing.  