### PR TITLE
add x-ref for macOS info

### DIFF
--- a/documentation/1.1/content/concepts/_index.md
+++ b/documentation/1.1/content/concepts/_index.md
@@ -78,7 +78,7 @@ examples are:
 On Windows and Linux platforms, this tends to be the user's environment that they have configured to be used when
 they log in. On macOS, native applications do not inherit the user's login environment.  Instead, the application
 inherits the environment configured by the `launchd` daemon process.  If you are running on macOS, then you should keep this in mind
-when the application doesn't behave as you expect.
+when the application doesn't behave as you expect. For more information, see [Project Settings]({{< relref "/navigate/project-settings.md" >}}).
 {{% /notice %}}
 
 #### User Preferences


### PR DESCRIPTION
Thought it might be helpful to cross-reference the extended macOS info on the Project Settings page from the Note in the Environment Variables section. 