### PR TITLE
updating to WDT 2.1.0 targets and enhancing PV behavior

### DIFF
--- a/electron/app/js/wdtValidateModel.js
+++ b/electron/app/js/wdtValidateModel.js
@@ -42,7 +42,7 @@ async function validateModel(currentWindow, stdoutChannel, stderrChannel, valida
 
   const env = {
     JAVA_HOME: javaHome,
-    WDT_CUSTOM_CONFIG: getWdtCustomConfigDirectory(validateConfig)
+    WDT_CUSTOM_CONFIG: getWdtCustomConfigDirectory()
   };
   getLogger().debug(`Invoking ${getValidateModelShellScript()} with args ${JSON.stringify(argList)} and environment ${JSON.stringify(env)}`);
 

--- a/electron/app/js/wktTools.js
+++ b/electron/app/js/wktTools.js
@@ -45,9 +45,8 @@ function getValidateModelShellScript() {
   return path.join(getWdtDirectory(), 'bin', 'validateModel' + scriptExtension);
 }
 
-function getWdtCustomConfigDirectory(config) {
-  const targetDomainLocation = config.targetDomainLocation || 'mii';
-  return path.join(getToolsDirectory(), 'wdt-config', targetDomainLocation);
+function getWdtCustomConfigDirectory() {
+  return path.join(getToolsDirectory(), 'wdt-config');
 }
 
 function isWdtErrorExitCode(exitCode) {

--- a/electron/app/locales/en/webui.json
+++ b/electron/app/locales/en/webui.json
@@ -545,6 +545,7 @@
   "domain-design-aux-image-registry-pull-email-help": "The image registry user's email address used to create the Kubernetes image pull secret for the auxiliary image.",
 
   "domain-design-clusters-title": "Clusters",
+  "domain-design-clusters-table-aria-label": "Clusters configuration table",
   "domain-design-no-clusters-message": "No clusters found for this domain. If your project has a model that defines clusters, please run Prepare Model to populate the clusters tables.",
   "domain-design-clusters-name-heading": "Cluster Name",
   "domain-design-clusters-replicas-heading": "Replicas",
@@ -554,6 +555,8 @@
   "domain-design-clusters-memory-request-heading": "Kubernetes Memory Request",
   "domain-design-edit-cluster-label": "Edit Cluster Settings",
   "domain-design-cluster-dialog-title": "Edit Cluster Settings",
+  "domain-design-add-cluster-label": "Add Cluster",
+  "domain-design-delete-cluster-label": "Delete Cluster",
 
   "domain-design-get-domain-status": "Get Domain Status",
   "domain-design-domain-status-label": "Domain Status: ",
@@ -574,6 +577,8 @@
 
   "domain-design-cluster-name-label": "Cluster Name",
   "domain-design-cluster-name-help": "The cluster name in the domain for which to enter settings.",
+  "domain-design-cluster-name-is-empty-error": "Cluster Name cannot be empty",
+  "domain-design-cluster-name-not-unique-error": "{{name}} is already present in cluster list [{{existingNames}}]",
   "domain-design-cluster-replicas-label": "Replicas",
   "domain-design-cluster-replicas-help": "The number of managed servers to start for the cluster.",
   "domain-design-cluster-min-heap-label": "Minimum Heap Size",
@@ -867,7 +872,6 @@
   "wdt-discoverer-online-discovery-failed-error-prefix": "Unable to discover domain {{adminUrl}} in online mode",
 
   "wdt-validator-aborted-error-title": "Validate Model Aborted",
-  "wdt-validator-domain-in-pv-message": "Validate Model has no meaning when the target domain location is an externally created Kubernetes persistent volume.",
   "wdt-validator-invalid-java-home-error-prefix": "Unable to validate model due to the Java Home being invalid",
   "wdt-validator-invalid-oracle-home-error-prefix": "Unable to validate model due to the Oracle Home being invalid",
   "wdt-validator-project-not-saved-error-prefix": "Unable to validate model because project save failed",
@@ -883,7 +887,6 @@
   "wdt-validator-validate-complete-message": "Validate Model successfully validated the model.",
 
   "wdt-preparer-aborted-error-title": "Prepare Model Aborted",
-  "wdt-preparer-domain-in-pv-message": "Prepare Model has no meaning when the target domain location is an externally created Kubernetes persistent volume.",
   "wdt-preparer-invalid-java-home-error-prefix": "Unable to prepare model due to the Java Home being invalid",
   "wdt-preparer-invalid-oracle-home-error-prefix": "Unable to prepare model due to the Oracle Home being invalid",
   "wdt-preparer-project-not-saved-error-prefix": "Unable to prepare model because project save failed",

--- a/tools/wdt-config/targets/vz-dii/target.json
+++ b/tools/wdt-config/targets/vz-dii/target.json
@@ -1,16 +1,13 @@
 {
   "model_filters" : {
     "discover": [
-      { "name": "vz_prep", "path": "@@TARGET_CONFIG_DIR@@/vz_filter.py" },
       { "id": "wko_filter" }
     ]
   },
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
-  "validation_method" : "wktui",
-  "credentials_method" : "secrets",
+  "validation_method" : "lax",
   "credentials_output_method" : "script",
   "exclude_domain_bin_contents": true,
   "wls_credentials_name" : "__weblogic-credentials__",
-  "additional_secrets": "runtime-encryption-secret",
   "additional_output" : "vz-application.yaml"
 }

--- a/tools/wdt-config/targets/vz-pv/target.json
+++ b/tools/wdt-config/targets/vz-pv/target.json
@@ -1,0 +1,14 @@
+{
+  "model_filters" : {
+    "discover": [
+      { "id": "wko_filter" }
+    ]
+  },
+  "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
+  "validation_method" : "lax",
+  "credentials_output_method" : "script",
+  "exclude_domain_bin_contents": true,
+  "wls_credentials_name" : "__weblogic-credentials__",
+  "additional_output" : "vz-application.yaml",
+  "use_persistent_volume" : true
+}

--- a/tools/wdt-config/targets/vz/target.json
+++ b/tools/wdt-config/targets/vz/target.json
@@ -1,12 +1,12 @@
 {
   "model_filters" : {
     "discover": [
-      { "name": "vz_prep", "path": "@@TARGET_CONFIG_DIR@@/vz_filter.py" },
       { "id": "wko_filter" }
     ]
   },
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
-  "validation_method" : "lax",
+  "validation_method" : "wktui",
+  "credentials_method" : "secrets",
   "credentials_output_method" : "script",
   "exclude_domain_bin_contents": true,
   "wls_credentials_name" : "__weblogic-credentials__",

--- a/tools/wdt-config/targets/wko-dii/target.json
+++ b/tools/wdt-config/targets/wko-dii/target.json
@@ -1,16 +1,13 @@
 {
   "model_filters" : {
     "discover": [
-      { "name": "wko_prep", "path": "@@TARGET_CONFIG_DIR@@/wko_operator_filter.py" },
       { "id": "wko_filter" }
     ]
   },
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
   "validation_method" : "wktui",
-  "credentials_method" : "secrets",
   "credentials_output_method" : "json",
   "exclude_domain_bin_contents": true,
   "wls_credentials_name" : "__weblogic-credentials__",
-  "additional_secrets": "runtime-encryption-secret",
   "additional_output" : "wko-domain.yaml"
 }

--- a/tools/wdt-config/targets/wko-pv/target.json
+++ b/tools/wdt-config/targets/wko-pv/target.json
@@ -1,0 +1,14 @@
+{
+  "model_filters" : {
+    "discover": [
+      { "id": "wko_filter" }
+    ]
+  },
+  "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
+  "validation_method" : "wktui",
+  "credentials_output_method" : "json",
+  "exclude_domain_bin_contents": true,
+  "wls_credentials_name" : "__weblogic-credentials__",
+  "additional_output" : "wko-domain.yaml",
+  "use_persistent_volume" : true
+}

--- a/tools/wdt-config/targets/wko/target.json
+++ b/tools/wdt-config/targets/wko/target.json
@@ -1,12 +1,12 @@
 {
   "model_filters" : {
     "discover": [
-      { "name": "wko_prep", "path": "@@TARGET_CONFIG_DIR@@/wko_operator_filter.py" },
       { "id": "wko_filter" }
     ]
   },
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
   "validation_method" : "wktui",
+  "credentials_method" : "secrets",
   "credentials_output_method" : "json",
   "exclude_domain_bin_contents": true,
   "wls_credentials_name" : "__weblogic-credentials__",

--- a/webui/src/js/models/wkt-project.js
+++ b/webui/src/js/models/wkt-project.js
@@ -111,6 +111,30 @@ function (ko, wdtConstructor, imageConstructor, kubectlConstructor, domainConstr
         }
         delete wktProjectJson.kubectl.extraPathDirectories;
       }
+
+      // Version 1.1.1 changes domain clusters to be persisted by UID instead of name
+      // to allow us to support adding new clusters on the domain page for the
+      // Domain in PV use case...
+      //
+      if ('k8sDomain' in wktProjectJson && 'clusters' in wktProjectJson.k8sDomain) {
+        const currentClusters = wktProjectJson.k8sDomain.clusters;
+        const newClusters = {};
+        for (const clusterName in currentClusters) {
+          const cluster = currentClusters[clusterName];
+          // This is tricky because the only way to tell if the cluster is in
+          // the old format is if there is no name field...
+          //
+          if (cluster.name) {
+            break;
+          }
+          cluster.name = clusterName;
+          const uid = utils.getShortUuid();
+          newClusters[uid] = cluster;
+        }
+        if (Object.keys(newClusters).length > 0) {
+          wktProjectJson.k8sDomain.clusters = newClusters;
+        }
+      }
     };
 
     this.setFromJson = (wktProjectJson, modelContentsJson) => {

--- a/webui/src/js/utils/wdt-preparer.js
+++ b/webui/src/js/utils/wdt-preparer.js
@@ -26,12 +26,6 @@ function(WdtActionsBase, project, wktConsole, i18n, projectIo, dialogHelper, val
       const errPrefix = 'wdt-preparer';
       const shouldCloseBusyDialog = !options.skipBusyDialog;
 
-      if (this.project.settings.targetDomainLocation.value === 'pv') {
-        const errMessage = i18n.t('wdt-preparer-domain-in-pv-message');
-        await window.api.ipc.invoke('show-info-message', errTitle, errMessage);
-        return Promise.resolve(false);
-      }
-
       const validationObject = this.getValidationObject('flow-prepare-model-name');
       if (validationObject.hasValidationErrors()) {
         const validationErrorDialogConfig = validationObject.getValidationErrorDialogConfig(errTitle);

--- a/webui/src/js/utils/wdt-validator.js
+++ b/webui/src/js/utils/wdt-validator.js
@@ -26,12 +26,6 @@ function(WdtActionsBase, project, wktConsole, i18n, projectIo, dialogHelper, val
       const errPrefix = 'wdt-validator';
       const shouldCloseBusyDialog = !options.skipBusyDialog;
 
-      if (this.project.settings.targetDomainLocation.value === 'pv') {
-        const errMessage = i18n.t('wdt-validator-domain-in-pv-message');
-        await window.api.ipc.invoke('show-info-message', errTitle, errMessage);
-        return Promise.resolve(false);
-      }
-
       const validationObject = this.getValidationObject('flow-validate-model-name');
       if (validationObject.hasValidationErrors()) {
         const validationErrorDialogConfig = validationObject.getValidationErrorDialogConfig(errTitle);

--- a/webui/src/js/viewModels/cluster-edit-dialog.js
+++ b/webui/src/js/viewModels/cluster-edit-dialog.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates.
  * Licensed under The Universal Permissive License (UPL), Version 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
 'use strict';

--- a/webui/src/js/viewModels/cluster-edit-dialog.js
+++ b/webui/src/js/viewModels/cluster-edit-dialog.js
@@ -36,14 +36,28 @@ function(accUtils, ko, i18n, project, ArrayDataProvider,
 
     this.project = project;
     this.cluster = args.cluster;
+    this.existingClusterNames = args.existingNames;
+    this.isDomainInPV = args.isDomainInPV;
     this.i18n = i18n;
 
+    this.nameIsUnique = {
+      validate: (value) => {
+        const existingNames = this.existingClusterNames;
+        if (!value) {
+          throw new Error(this.labelMapper('name-is-empty-error'));
+        } else if (Array.isArray(existingNames) && existingNames.length > 0 && existingNames.includes(value)) {
+          throw new Error(this.labelMapper('name-not-unique-error',
+            { name: value, existingNames: existingNames.join(',')}));
+        }
+      },
+    };
     this.integerConverter = new ojConverterNumber.IntlNumberConverter({
       style: 'decimal',
       roundingMode: 'HALF_DOWN',
       maximumFractionDigits: 0,
       useGrouping: false
     });
+
 
     // create an observable property for each simple field
     this['maxServers'] = this.cluster.maxServers;

--- a/webui/src/js/viewModels/domain-design-view.js
+++ b/webui/src/js/viewModels/domain-design-view.js
@@ -21,6 +21,10 @@ function (project, accUtils, utils, ko, i18n, screenUtils, BufferingDataProvider
         this.applyAuxImageConfig(newValue);
       }));
 
+      // subscriptions.push(this.project.k8sDomain.clusters.observable.subscribe(() => {
+      //   document.getElementById('clusters-table').refresh();
+      // }));
+
       subscriptions.push(project.image.createPrimaryImage.observable.subscribe(() => {
         document.getElementById('create-image-switch').refresh();
         const primaryImageTag = document.getElementById('primary-image-tag');
@@ -270,6 +274,14 @@ function (project, accUtils, utils, ko, i18n, screenUtils, BufferingDataProvider
       {
         'className': 'wkt-table-delete-cell',
         'headerClassName': 'wkt-table-add-header',
+        'headerTemplate': 'chooseHeaderTemplate',
+        'template': 'actionTemplate',
+        'sortable': 'disable',
+        width: viewHelper.BUTTON_COLUMN_WIDTH
+      },
+      {
+        'className': 'wkt-table-delete-cell',
+        'headerClassName': 'wkt-table-add-header',
         'headerTemplate': 'headerTemplate',
         'template': 'actionTemplate',
         'sortable': 'disable',
@@ -287,7 +299,11 @@ function (project, accUtils, utils, ko, i18n, screenUtils, BufferingDataProvider
     this.handleEditCluster = (event, context) => {
       const index = context.item.index;
       const cluster = this.project.k8sDomain.clusters.observable()[index];
-      const options = { cluster: cluster };
+      const existingClusterNames = this.project.k8sDomain.clusters.observable()
+        .filter(item => item.name !== cluster.name).map(item => { return item.name; });
+
+      console.log(`existingClusterNames = ${existingClusterNames}`);
+      const options = { cluster: cluster, existingNames: existingClusterNames, isDomainInPV: this.isDomainInPV() };
 
       dialogHelper.promptDialog('cluster-edit-dialog', options).then(result => {
         if (result) {
@@ -299,6 +315,7 @@ function (project, accUtils, utils, ko, i18n, screenUtils, BufferingDataProvider
             }
           });
           if (changed) {
+            // FIXME - deal with cluster name changes that conflict with existing names...
             this.project.k8sDomain.clusters.observable.replace(cluster, cluster);
           }
         }
@@ -310,6 +327,40 @@ function (project, accUtils, utils, ko, i18n, screenUtils, BufferingDataProvider
       this.clustersEditRow({ rowKey: null });
     };
 
+    const generatedClusterNameRegex = /^new-cluster-(\d+)$/;
+
+    this.generateNewClusterName = () => {
+      let index = 1;
+      this.project.k8sDomain.clusters.observable().forEach(cluster => {
+        const match = cluster.name.match(generatedClusterNameRegex);
+        if (match) {
+          const indexFound = Number(match[1]);
+          if (indexFound >= index) {
+            index = indexFound + 1;
+          }
+        }
+      });
+      return `new-cluster-${index}`;
+    };
+
+    this.handleAddCluster = () => {
+      const clusterToAdd = {
+        uid: utils.getShortUuid(),
+        name: this.generateNewClusterName(),
+        // In the case of Domain in PV where the user is adding a cluster definition
+        // without running PrepareModel, we have no information on the cluster size
+        // so just set replicas to zero and maxServers to the max value possible.
+        //
+        replicas: 0,
+        maxServers: Number.MAX_SAFE_INTEGER
+      };
+      this.project.k8sDomain.clusters.addNewItem(clusterToAdd);
+    };
+
+    this.handleDeleteCluster = (event, context) => {
+      const index = context.item.index;
+      this.project.k8sDomain.clusters.observable.splice(index, 1);
+    };
 
     this.modelHasNoProperties = () => {
       return this.project.wdtModel.getMergedPropertiesContent().value.length === 0;

--- a/webui/src/js/views/cluster-edit-dialog.html
+++ b/webui/src/js/views/cluster-edit-dialog.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates.
  Licensed under The Universal Permissive License (UPL), Version 1.0 as shown at https://oss.oracle.com/licenses/upl/
  -->
 <oj-dialog id="clusterEditDialog" class="wkt-cluster-edit-dialog" initial-visibility="hide">

--- a/webui/src/js/views/cluster-edit-dialog.html
+++ b/webui/src/js/views/cluster-edit-dialog.html
@@ -13,7 +13,8 @@
           <oj-input-text class="wkt-can-readonly-field"
                          label-hint="[[labelMapper('name-label')]]"
                          value="{{name.observable}}"
-                         readonly="true"
+                         readonly="[[isDomainInPV === false]]"
+                         validators="[[[nameIsUnique]]]"
                          help.instruction="[[labelMapper('name-help')]]">
           </oj-input-text>
 

--- a/webui/src/js/views/domain-design-view.html
+++ b/webui/src/js/views/domain-design-view.html
@@ -277,6 +277,7 @@
   </div>
   <oj-table id="clusters-table"
             class="wkt-domain-clusters-table"
+            :aria-label="[[labelMapper('clusters-table-aria-label')]]"
             data="[[clustersDP]]"
             display="grid"
             horizontal-grid-visible="enabled"
@@ -297,11 +298,29 @@
             <oj-bind-text value="[[labelMapper('edit-cluster-label')]]"></oj-bind-text>
           </oj-button>
         </td>
+        <td>
+          <oj-button display="icons"
+                     chroming="borderless"
+                     disabled="[[isDomainInPV() === false]]"
+                     on-oj-action="[[handleDeleteCluster]]">
+            <span slot="endIcon" class="oj-ux-ico-trash"></span>
+            <oj-bind-text value="[[labelMapper('delete-cluster-label')]]"></oj-bind-text>
+          </oj-button>
+        </td>
       </tr>
     </template>
-    <template slot="headerTemplate">
+    <template slot="chooseHeaderTemplate">
       <oj-button display="icons" chroming="borderless" disabled="true">
         <span slot="endIcon"></span>
+      </oj-button>
+    </template>
+    <template slot="headerTemplate" data-oj-as="header">
+      <oj-button display="icons"
+                 chroming="borderless"
+                 disabled="[[isDomainInPV() === false]]"
+                 on-oj-action="[[handleAddCluster]]">
+        <span slot="endIcon" class="oj-ux-ico-plus"></span>
+        <oj-bind-text value="[[labelMapper('add-cluster-label')]]"></oj-bind-text>
       </oj-button>
     </template>
     <template slot="noData">

--- a/webui/src/js/views/ingress-design-view.html
+++ b/webui/src/js/views/ingress-design-view.html
@@ -200,8 +200,7 @@
           <td>
             <oj-bind-text value="[[row.data.targetPort]]"></oj-bind-text>
           </td>
-          <oj-bind-if
-                  test="[[!isAccessPointDefined(row.data.accessPoint)]]">
+          <oj-bind-if test="[[!isAccessPointDefined(row.data.accessPoint)]]">
             <td>
               <oj-bind-text value="[[row.data.accessPoint]]"></oj-bind-text>
             </td>

--- a/webui/src/js/views/ingress-design-view.html
+++ b/webui/src/js/views/ingress-design-view.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates.
  Licensed under The Universal Permissive License (UPL), Version 1.0 as shown at https://oss.oracle.com/licenses/upl/
  -->
 <h6 class="wkt-subheading"><oj-bind-text value="[[labelMapper('title')]]"></oj-bind-text></h6>


### PR DESCRIPTION
Updating code to support new WDT 2.1.0 targets
Allowing `Domain in PV` projects to:

- Run Validate Model and Prepare Model Actions.
- Add/Remove/Edit clusters on the Domain page for situations where there is no model.
