### PR TITLE
Increasing the robustness of the Remote Console backend port handling 

### DIFF
--- a/electron/app/js/wktWindow.js
+++ b/electron/app/js/wktWindow.js
@@ -825,6 +825,11 @@ async function createWindow() {
     userSettings.setWindowSize(winSize);
   });
 
+  newWindow.once('ready-to-show', () => {
+    const { getWebLogicRemoteConsoleBackendPort } = require('./wlRemoteConsoleUtils');
+    sendToWindow('set-wrc-backend-port', getWebLogicRemoteConsoleBackendPort());
+  });
+
   newWindow.on('close', (event) => {
     getLogger().debug('Received window close event on Window ID %s', newWindow.id);
     if (!newWindow.skipDirtyCheck) {

--- a/electron/app/js/wktWindow.js
+++ b/electron/app/js/wktWindow.js
@@ -825,11 +825,6 @@ async function createWindow() {
     userSettings.setWindowSize(winSize);
   });
 
-  newWindow.once('ready-to-show', () => {
-    const { getWebLogicRemoteConsoleBackendPort } = require('./wlRemoteConsoleUtils');
-    sendToWindow('set-wrc-backend-port', getWebLogicRemoteConsoleBackendPort());
-  });
-
   newWindow.on('close', (event) => {
     getLogger().debug('Received window close event on Window ID %s', newWindow.id);
     if (!newWindow.skipDirtyCheck) {

--- a/electron/app/js/wlRemoteConsoleUtils.js
+++ b/electron/app/js/wlRemoteConsoleUtils.js
@@ -51,7 +51,10 @@ async function startWebLogicRemoteConsoleBackend(currentWindow, skipVersionCheck
         _wlRemoteConsoleChildProcess.on('exit', (code) => {
           getLogger().info('WebLogic Remote Console backend process exited with code %s', code);
           _wlRemoteConsolePort = undefined;
-          BrowserWindow.getAllWindows().forEach(win => sendToWindow(win, 'set-wrc-backend-port', _wlRemoteConsolePort));
+          BrowserWindow.getAllWindows().forEach(win => {
+            getLogger().debug('Sending new Remote Console backend port %s to Window ID %s', _wlRemoteConsolePort, win.id);
+            sendToWindow(win, 'set-wrc-backend-port', _wlRemoteConsolePort);
+          });
         });
 
         const stdoutLines = readline.createInterface({ input: _wlRemoteConsoleChildProcess.stdout });
@@ -66,7 +69,10 @@ async function startWebLogicRemoteConsoleBackend(currentWindow, skipVersionCheck
             if (matcher) {
               foundPort = true;
               _wlRemoteConsolePort = matcher[1];
-              BrowserWindow.getAllWindows().forEach(win => sendToWindow(win, 'set-wrc-backend-port', _wlRemoteConsolePort));
+              BrowserWindow.getAllWindows().forEach(win => {
+                getLogger().debug('Sending new Remote Console backend port %s to Window ID %s', _wlRemoteConsolePort, win.id);
+                sendToWindow(win, 'set-wrc-backend-port', _wlRemoteConsolePort);
+              });
             }
           }
         });

--- a/electron/app/js/wlRemoteConsoleUtils.js
+++ b/electron/app/js/wlRemoteConsoleUtils.js
@@ -7,7 +7,7 @@
 
 const path = require('path');
 const readline = require('readline');
-const { app, dialog } = require('electron');
+const { app, BrowserWindow, dialog } = require('electron');
 const fsPromises = require('fs/promises');
 
 const userSettings = require('./userSettings');
@@ -21,8 +21,13 @@ const { spawnDaemonChildProcess } = require('./childProcessExecutor');
 const { wlRemoteConsoleFrontendVersion } = require('../webui.json');
 
 let _wlRemoteConsoleChildProcess;
+let _wlRemoteConsolePort;
 
 /* global process */
+function getWebLogicRemoteConsoleBackendPort() {
+  return _wlRemoteConsolePort;
+}
+
 async function startWebLogicRemoteConsoleBackend(currentWindow, skipVersionCheck = false) {
   if (_wlRemoteConsoleChildProcess) {
     return Promise.resolve();
@@ -45,6 +50,8 @@ async function startWebLogicRemoteConsoleBackend(currentWindow, skipVersionCheck
         });
         _wlRemoteConsoleChildProcess.on('exit', (code) => {
           getLogger().info('WebLogic Remote Console backend process exited with code %s', code);
+          _wlRemoteConsolePort = undefined;
+          BrowserWindow.getAllWindows().forEach(win => sendToWindow(win, 'set-wrc-backend-port', _wlRemoteConsolePort));
         });
 
         const stdoutLines = readline.createInterface({ input: _wlRemoteConsoleChildProcess.stdout });
@@ -58,7 +65,8 @@ async function startWebLogicRemoteConsoleBackend(currentWindow, skipVersionCheck
             const matcher = line.match(portRegex);
             if (matcher) {
               foundPort = true;
-              sendToWindow(currentWindow, 'set-wrc-backend-port', matcher[1]);
+              _wlRemoteConsolePort = matcher[1];
+              BrowserWindow.getAllWindows().forEach(win => sendToWindow(win, 'set-wrc-backend-port', _wlRemoteConsolePort));
             }
           }
         });
@@ -505,6 +513,7 @@ async function _getDefaultLocationForLinux() {
 module.exports = {
   getDefaultDirectoryForOpenDialog,
   getDefaultWebLogicRemoteConsoleHome,
+  getWebLogicRemoteConsoleBackendPort,
   setWebLogicRemoteConsoleHomeAndStart,
   startWebLogicRemoteConsoleBackend
 };

--- a/electron/app/main.js
+++ b/electron/app/main.js
@@ -35,7 +35,8 @@ const openSSLUtils = require('./js/openSSLUtils');
 const osUtils = require('./js/osUtils');
 const { initializeAutoUpdater, registerAutoUpdateListeners, installUpdates, getUpdateInformation } = require('./js/appUpdater');
 const { startWebLogicRemoteConsoleBackend, getDefaultDirectoryForOpenDialog, setWebLogicRemoteConsoleHomeAndStart,
-  getDefaultWebLogicRemoteConsoleHome } = require('./js/wlRemoteConsoleUtils');
+  getDefaultWebLogicRemoteConsoleHome, getWebLogicRemoteConsoleBackendPort
+} = require('./js/wlRemoteConsoleUtils');
 
 const { getHttpsProxyUrl, getBypassProxyHosts } = require('./js/userSettings');
 const { sendToWindow } = require('./js/windowUtils');
@@ -225,10 +226,17 @@ class Main {
               }
 
               sendToWindow(currentWindow, 'show-startup-dialogs', startupInformation);
+              const port = getWebLogicRemoteConsoleBackendPort();
+              this._logger.debug('Sending Remote Console backend port %s to Window ID %s', port, currentWindow.id);
+              sendToWindow(currentWindow, 'set-wrc-backend-port', port);
             });
           }
 
           this._startupDialogsShownAlready = true;
+        } else {
+          const port = getWebLogicRemoteConsoleBackendPort();
+          this._logger.debug('Sending Remote Console backend port %s to Window ID %s', port, currentWindow.id);
+          sendToWindow(currentWindow, 'set-wrc-backend-port', port);
         }
       });
     });

--- a/webui/src/js/windowStateUtils.js
+++ b/webui/src/js/windowStateUtils.js
@@ -256,6 +256,7 @@ function(wktProject, wktConsole, wdtDiscoverer, dialogHelper, projectIO,
   });
 
   window.api.ipc.receive('set-wrc-backend-port', (port) => {
+    wktLogger.debug('Received Remote Console backend port %s', port);
     wktProject.wdtModel.internal.wlRemoteConsolePort(port);
   });
 


### PR DESCRIPTION
This PR makes several changes to the way the backend port is communicated to the BrowserWindows:

1. When the backend starts, it pushes the `set-wrc-backend-port` event to all open BrowserWindows.
2. For every new BrowserWindow, we push the current backend port value to the window during the IPC handler for `window-is-ready`.
3. When the backend process exits, it pushed the `set-wrc-backend-port` event to all open BrowserWindows to set the window's backend port to undefined.

In addition, this PR also short-circuits the deactivate/create process for the wdt-model-designer's data provider when the model changes due to receiving the changesAutoDownloaded callback. This should make it so that the only time the deactivate/create cycle is performed when the model changes due to an action cause by a menu invocation (or the Prepare Model button).