### PR TITLE
New file type for i18n translations

### DIFF
--- a/wktui.wptg
+++ b/wktui.wptg
@@ -1,5 +1,5 @@
 Languages: Std_Admin
 
-electron/app/locales/en
+electron/app/locales/%j
     electron.json FileType: i18next-json
     webui.json FileType: i18next-json

--- a/wktui.wptg
+++ b/wktui.wptg
@@ -1,5 +1,5 @@
 Languages: Std_Admin
 
 electron/app/locales/en
-    electron.json FileType: JSON
-    webui.json FileType: JSON
+    electron.json FileType: i18next-json
+    webui.json FileType: i18next-json

--- a/wktui.wptg
+++ b/wktui.wptg
@@ -1,5 +1,5 @@
 Languages: Std_Admin
 
-electron/app/locales
-    %j/electron.json FileType: i18next-json
-    %j/webui.json FileType: i18next-json
+electron/app/locales/%J
+    electron.json FileType: i18next-json
+    webui.json FileType: i18next-json

--- a/wktui.wptg
+++ b/wktui.wptg
@@ -1,5 +1,5 @@
 Languages: Std_Admin
 
-electron/app/locales/%j
-    electron.json FileType: i18next-json
-    webui.json FileType: i18next-json
+electron/app/locales
+    %j/electron.json FileType: i18next-json
+    %j/webui.json FileType: i18next-json


### PR DESCRIPTION
The WPTG file needed to be changed after the translation team updated their allowed types.