### PR TITLE
Fix 4.0 domain status due to changes in operator 4.0

### DIFF
--- a/electron/app/locales/en/webui.json
+++ b/electron/app/locales/en/webui.json
@@ -597,6 +597,7 @@
   "domain-design-domain-status-title": "Domain Status",
   "domain-design-domain-status-overallstatus": "Domain Status:",
   "domain-design-domain-status-introspectJobFailureCount": "Introspect Job Failure Count:",
+  "domain-design-domain-status-observedGeneration": "Observed Generation:",
   "domain-design-domain-status-message": "Last Error Message:",
   "domain-design-domain-status-conditions": "Conditions:",
   "domain-design-domain-status-clusterstatus": "Cluster Status:",

--- a/webui/src/js/utils/k8s-domain-actions-base.js
+++ b/webui/src/js/utils/k8s-domain-actions-base.js
@@ -117,7 +117,10 @@ function (WktActionsBase, project, wktConsole, i18n, projectIo, dialogHelper) {
             } else if (completeCondition.status === 'False' && availableCondition.status === 'False') {
               result['domainOverallStatus'] = i18n.t('k8s-domain-status-checker-domain-status-available',
                 {reason: latestCondition.reason});
-            } else {
+            } else if (completeCondition.status === 'True' && availableCondition.status === 'False') {
+              result['domainOverallStatus'] = i18n.t('k8s-domain-status-checker-domain-status-available',
+                {reason: latestCondition.reason});
+            }  else {
               // should never happened?
               result['domainOverallStatus'] = i18n.t('k8s-domain-status-checker-domain-status-unknown',
                 {reason: latestCondition.reason});

--- a/webui/src/js/viewModels/domain-status-dialog.js
+++ b/webui/src/js/viewModels/domain-status-dialog.js
@@ -54,18 +54,19 @@ function(accUtils, ko, jsyaml, i18n, project) {
     this.domainHasError = false;
     this.isOperatorVersion4orHigher = false;
 
-    if ('installedVersion' in this.project.wko && this.project.wko.installedVersion.value.startsWith('4')) {
-      this.isOperatorVersion4orHigher = true;
-    } else if (! 'installedVersion' in this.project.wko ) {
+    if (!project.wko.installedVersion.hasValue() ||
+        window.api.utils.compareVersions(project.wko.installedVersion.value, '4.0.0') >= 0) {
       this.isOperatorVersion4orHigher = true;
     }
-    
+
     if ('status' in this.domainStatus && 'conditions' in this.domainStatus.status) {
       this.domainConditions = this.makeYamlOutput(this.domainStatus.status.conditions);
       this.domainClusterStatus = this.makeYamlOutput(this.domainStatus.status.clusters);
       this.domainServerStatus = this.makeYamlOutput(this.domainStatus.status.servers);
       this.domainName = this.domainStatus.spec.domainUID;
       if (this.isOperatorVersion4orHigher) {
+        // 4.0 higher is not named introspectJobFailureCount but observeredGeneation in the status
+        // text in the diaglog have been changed to Observed Generation to match, this is just a holder of the value
         this.introspectJobFailureCount = this.domainStatus.status.observedGeneration;
       } else {
         this.introspectJobFailureCount = this.domainStatus.status.introspectJobFailureCount;

--- a/webui/src/js/viewModels/domain-status-dialog.js
+++ b/webui/src/js/viewModels/domain-status-dialog.js
@@ -55,11 +55,11 @@ function(accUtils, ko, jsyaml, i18n, project) {
     this.isOperatorVersion4orHigher = false;
 
     if ('installedVersion' in this.project.wko && this.project.wko.installedVersion.value.startsWith('4')) {
-      this.isOperator4orHigher = true;
+      this.isOperatorVersion4orHigher = true;
     } else if (! 'installedVersion' in this.project.wko ) {
-      this.isOperator4orHigher = true;
+      this.isOperatorVersion4orHigher = true;
     }
-
+    
     if ('status' in this.domainStatus && 'conditions' in this.domainStatus.status) {
       this.domainConditions = this.makeYamlOutput(this.domainStatus.status.conditions);
       this.domainClusterStatus = this.makeYamlOutput(this.domainStatus.status.clusters);

--- a/webui/src/js/viewModels/domain-status-dialog.js
+++ b/webui/src/js/viewModels/domain-status-dialog.js
@@ -52,13 +52,25 @@ function(accUtils, ko, jsyaml, i18n, project) {
     this.domainServerStatus = '';
     this.introspectJobFailureCount = 0;
     this.domainHasError = false;
+    this.isOperatorVersion4orHigher = false;
+
+    if ('installedVersion' in this.project.wko && this.project.wko.installedVersion.value.startsWith('4')) {
+      this.isOperator4orHigher = true;
+    } else if (! 'installedVersion' in this.project.wko ) {
+      this.isOperator4orHigher = true;
+    }
 
     if ('status' in this.domainStatus && 'conditions' in this.domainStatus.status) {
       this.domainConditions = this.makeYamlOutput(this.domainStatus.status.conditions);
       this.domainClusterStatus = this.makeYamlOutput(this.domainStatus.status.clusters);
       this.domainServerStatus = this.makeYamlOutput(this.domainStatus.status.servers);
       this.domainName = this.domainStatus.spec.domainUID;
-      this.introspectJobFailureCount = this.domainStatus.status.introspectJobFailureCount;
+      if (this.isOperatorVersion4orHigher) {
+        this.introspectJobFailureCount = this.domainStatus.status.observedGeneration;
+      } else {
+        this.introspectJobFailureCount = this.domainStatus.status.introspectJobFailureCount;
+      }
+
       const conditions = this.domainStatus.status.conditions;
       conditions.sort((a, b) => {
         if ( a.lastTransitionTime < b.lastTransitionTime ){

--- a/webui/src/js/views/domain-status-dialog.html
+++ b/webui/src/js/views/domain-status-dialog.html
@@ -18,9 +18,18 @@
   </div>
 
   <div class="oj-panel wkt-notop">
-    <oj-label for="introspectJobFailureCount">
-      <oj-bind-text value="{{labelMapper('domain-status-introspectJobFailureCount')}}"></oj-bind-text>
-    </oj-label>
+    <oj-bind-if test="[[isOperatorVersion4orHigher === false]]">
+      <oj-label for="introspectJobFailureCount">
+        <oj-bind-text value="{{labelMapper('domain-status-introspectJobFailureCount')}}"></oj-bind-text>
+      </oj-label>
+    </oj-bind-if>
+
+    <oj-bind-if test="[[isOperatorVersion4orHigher === true]]">
+      <oj-label for="introspectJobFailureCount">
+        <oj-bind-text value="{{labelMapper('domain-status-observedGeneration')}}"></oj-bind-text>
+      </oj-label>
+    </oj-bind-if>
+
     <br>
     <oj-input-text id="introspectJobFailureCount" value="{{introspectJobFailureCount}}" readonly="true"></oj-input-text>
   </div>


### PR DESCRIPTION
This PR fixes the domain status dialog because operator 4.0 no longer have introspectoJobFailureCount. 